### PR TITLE
Fix: Ensure gradient headline displays correctly by safelisting classes

### DIFF
--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -8,6 +8,14 @@ const config: Config = {
     "./app/**/*.{js,ts,jsx,tsx,mdx}",
     "*.{js,ts,jsx,tsx,mdx}"
   ],
+  safelist: [
+    'bg-gradient-to-r',
+    'from-purple-400',
+    'via-blue-400',
+    'to-indigo-400',
+    'bg-clip-text',
+    'text-transparent'
+  ],
   theme: {
   	extend: {
   		colors: {


### PR DESCRIPTION
The headline "Discover Your Personal Destiny Map with KIRA" was sometimes rendering as a solid color block instead of with its intended gradient text effect. This was likely due to Tailwind CSS purging the necessary utility classes in production builds.

This commit addresses the issue by adding the following classes to the `safelist` in `tailwind.config.ts`:
- `bg-gradient-to-r`
- `from-purple-400`
- `via-blue-400`
- `to-indigo-400`
- `bg-clip-text`
- `text-transparent`

This ensures these classes are not removed during the build process, allowing the gradient text to render as expected.

The KIRA logo in the header was previously changed to an SVG and was not the target of this specific fix.