### PR TITLE
Update: Change headline to plain text

### DIFF
--- a/components/hero-section.tsx
+++ b/components/hero-section.tsx
@@ -1,7 +1,7 @@
 export function HeroSection() {
   return (
     <section className="text-center px-6 py-20 max-w-4xl mx-auto">
-      <h1 className="text-5xl md:text-7xl font-bold mb-6 bg-gradient-to-r from-purple-400 via-blue-400 to-indigo-400 bg-clip-text text-transparent leading-tight">
+      <h1 className="text-5xl md:text-7xl font-bold mb-6 text-white leading-tight">
         Discover Your Personal Destiny Map with KIRA
       </h1>
 


### PR DESCRIPTION
Per your request, the main headline "Discover Your Personal Destiny Map with KIRA" in the hero section has been changed to display as plain white text. The previous gradient text effect has been removed.

Modified `components/hero-section.tsx` by:
- Removing Tailwind CSS classes: `bg-gradient-to-r`, `from-purple-400`, `via-blue-400`, `to-indigo-400`, `bg-clip-text`, `text-transparent`.
- Adding `text-white` class for visibility against the dark background.